### PR TITLE
Add Lumen support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Added a notice about not using the factory pattern described in the SDK documentation when using this package. 
   (Although not a code change, adding it in the changelog to enhance visibility)
+* Added support for [Lumen](https://lumen.laravel.com/)
+* Updated `kreait/firebase-php` to `^4.38.1`
 
 ## 1.2.0 - 2019-10-26
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 A Laravel package for the [Firebase PHP Admin SDK](https://github.com/kreait/firebase-php).
 
 [![Current version](https://img.shields.io/packagist/v/kreait/laravel-firebase.svg?logo=composer)](https://packagist.org/packages/kreait/laravel-firebase)
-[![Firebase Admin SDK version](https://img.shields.io/badge/Firebase%20Admin%20SDK-%5E4.32.0-blue)](https://packagist.org/packages/kreait/firebase-php)
+[![Firebase Admin SDK version](https://img.shields.io/badge/Firebase%20Admin%20SDK-%5E4.35.0-blue)](https://packagist.org/packages/kreait/firebase-php)
 ![Supported Laravel versions](https://img.shields.io/badge/Laravel-%3E%3D5.8-blue)
+![Supported Lumen versions](https://img.shields.io/badge/Lumen-%3E%3D5.8-blue)
 [![Discord](https://img.shields.io/discord/523866370778333184.svg?color=7289da&logo=discord)](https://discord.gg/nbgVfty)
 
 * [Installation](#installation)
@@ -14,18 +15,20 @@ A Laravel package for the [Firebase PHP Admin SDK](https://github.com/kreait/fir
 
 ## Installation
 
-This package requires Laravel 5.8 and higher.
+This package requires Laravel 5.8 and higher or Lumen 5.8 and higher.
 
 ```bash
 composer require kreait/laravel-firebase
 ```
 
-If you don't use package auto-discovery, add the following service provider in `config/app.php`
+If you use Lumen or don't use Laravel's package auto-discovery, add the following service provider in 
+`config/app.php` (Laravel) or `bootstrap/app.php` (Lumen):
+
+### Laravel
 
 ```php
-// config/app.php
 <?php
-
+// config/app.php
 return [
     // ...
     'providers' => [
@@ -34,6 +37,15 @@ return [
     ]
     // ...   
 ];
+```
+
+### Lumen
+
+```php
+<?php
+// bootstrap/app.php
+
+$app->register(Kreait\Laravel\Firebase\ServiceProvider::class);
 ```
 
 ## Configuration
@@ -57,10 +69,15 @@ FIREBASE_CREDENTIALS=relative/path/to/firebase_credentials.json
 ```
 
 For further configuration, please see [config/firebase.php](config/firebase.php). You can modify the configuration
-by copying it to your local `config` directory with the publish command:
+by copying it to your local `config` directory:
 
 ```bash
+# Laravel
 php artisan vendor:publish --provider="Kreait\Laravel\Firebase\ServiceProvider" --tag=config
+
+# Lumen
+mkdir -p config
+cp vendor/kreait/firebase-laravel/config/firebase.php config/firebase.php
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,12 @@
         }
     ],
     "require": {
-        "kreait/firebase-php": "^4.35.0",
+        "kreait/firebase-php": "^4.38.1",
         "illuminate/contracts": "^5.8|^6.0",
         "illuminate/support": "^5.8|^6.0"
+    },
+    "require-dev": {
+        "laravel/lumen-framework": "^5.8|^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,22 +4,33 @@ declare(strict_types=1);
 
 namespace Kreait\Laravel\Firebase;
 
-use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Container\Container;
+use Laravel\Lumen\Application as Lumen;
 use Kreait\Firebase;
 
 final class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
     public function boot()
     {
-        if ($this->app->runningInConsole()) {
-            $this->publishes([
-                __DIR__ . '/../config/firebase.php' => $this->app->configPath('firebase.php'),
-            ], 'config');
+        if (!$this->app->runningInConsole()) {
+            return;
         }
+
+        if ($this->app instanceof Lumen) {
+            return;
+        }
+
+        $this->publishes([
+            __DIR__ . '/../config/firebase.php' => $this->app->configPath('firebase.php'),
+        ], 'config');
     }
 
     public function register()
     {
+        if ($this->app instanceof Lumen) {
+            $this->app->configure('firebase');
+        }
+
         $this->mergeConfigFrom(__DIR__.'/../config/firebase.php', 'firebase');
 
         $this->registerComponents();
@@ -27,7 +38,49 @@ final class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
     private function registerComponents()
     {
-        $this->app->singleton(Firebase\Factory::class, static function (Application $app) {
+        $this->registerFactory();
+
+        $this->app->singleton(Firebase\Auth::class, static function (Container $app) {
+            return $app->make(Firebase\Factory::class)->createAuth();
+        });
+        $this->app->alias(Firebase\Auth::class, 'firebase.auth');
+
+        $this->app->singleton(Firebase\Database::class, static function (Container $app) {
+            return $app->make(Firebase\Factory::class)->createDatabase();
+        });
+        $this->app->alias(Firebase\Database::class, 'firebase.database');
+
+        $this->app->singleton(Firebase\DynamicLinks::class, static function (Container $app) {
+            $defaultDynamicLinksDomain = $app->make('config')['firebase']['dynamic_links']['default_domain'] ?? null;
+
+            return $app->make(Firebase\Factory::class)->createDynamicLinksService($defaultDynamicLinksDomain);
+        });
+        $this->app->alias(Firebase\DynamicLinks::class, 'firebase.dynamic_links');
+
+        $this->app->singleton(Firebase\Firestore::class, static function (Container $app) {
+            return $app->make(Firebase\Factory::class)->createFirestore();
+        });
+        $this->app->alias(Firebase\Firestore::class, 'firebase.firestore');
+
+        $this->app->singleton(Firebase\Messaging::class, static function (Container $app) {
+            return $app->make(Firebase\Factory::class)->createMessaging();
+        });
+        $this->app->alias(Firebase\Messaging::class, 'firebase.messaging');
+
+        $this->app->singleton(Firebase\RemoteConfig::class, static function (Container $app) {
+            return $app->make(Firebase\Factory::class)->createRemoteConfig();
+        });
+        $this->app->alias(Firebase\RemoteConfig::class, 'firebase.remote_config');
+
+        $this->app->singleton(Firebase\Storage::class, static function (Container $app) {
+            return $app->make(Firebase\Factory::class)->createStorage();
+        });
+        $this->app->alias(Firebase\Storage::class, 'firebase.storage');
+    }
+
+    private function registerFactory()
+    {
+        $this->app->singleton(Firebase\Factory::class, static function (Container $app) {
             $factory = new Firebase\Factory();
 
             $config = $app->make('config')['firebase'];
@@ -57,42 +110,5 @@ final class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
             return $factory;
         });
-
-        $this->app->singleton(Firebase\Auth::class, static function (Application $app) {
-            return $app->make(Firebase\Factory::class)->createAuth();
-        });
-        $this->app->alias(Firebase\Auth::class, 'firebase.auth');
-
-        $this->app->singleton(Firebase\Database::class, static function (Application $app) {
-            return $app->make(Firebase\Factory::class)->createDatabase();
-        });
-        $this->app->alias(Firebase\Database::class, 'firebase.database');
-
-        $this->app->singleton(Firebase\DynamicLinks::class, static function (Application $app) {
-            $defaultDynamicLinksDomain = $app->make('config')['firebase']['dynamic_links']['default_domain'] ?? null;
-
-            return $app->make(Firebase\Factory::class)->createDynamicLinksService($defaultDynamicLinksDomain);
-        });
-        $this->app->alias(Firebase\DynamicLinks::class, 'firebase.dynamic_links');
-
-        $this->app->singleton(Firebase\Firestore::class, static function (Application $app) {
-            return $app->make(Firebase\Factory::class)->createFirestore();
-        });
-        $this->app->alias(Firebase\Firestore::class, 'firebase.firestore');
-
-        $this->app->singleton(Firebase\Messaging::class, static function (Application $app) {
-            return $app->make(Firebase\Factory::class)->createMessaging();
-        });
-        $this->app->alias(Firebase\Messaging::class, 'firebase.messaging');
-
-        $this->app->singleton(Firebase\RemoteConfig::class, static function (Application $app) {
-            return $app->make(Firebase\Factory::class)->createRemoteConfig();
-        });
-        $this->app->alias(Firebase\RemoteConfig::class, 'firebase.remote_config');
-
-        $this->app->singleton(Firebase\Storage::class, static function (Application $app) {
-            return $app->make(Firebase\Factory::class)->createStorage();
-        });
-        $this->app->alias(Firebase\Storage::class, 'firebase.storage');
     }
 }


### PR DESCRIPTION
Closes #8 

### Changes

- Added check if the package is used in a Lumen context and return early
- Replaced type hints with PHPDocs for flexibility
- Added Lumen instructions to the README

### How to test

Add the following line to the `require` section of your `composer.json`:

```
"kreait/laravel-firebase": "dev-lumen-support"
```

:octocat: 