### PR TITLE
Add option to configure credentials from array

### DIFF
--- a/config/firebase.php
+++ b/config/firebase.php
@@ -34,6 +34,17 @@ return [
         'file' => env('FIREBASE_CREDENTIALS'),
 
         /**
+         * Please uncomment the following lines if you can't use the credentials
+         * file and must configure Firebase from environment variables
+         */
+        // 'array' => [
+        //     'project_id' => env('FIREBASE_PROJECT_ID'),
+        //     'client_id' => env('FIREBASE_CLIENT_ID'),
+        //     'client_email' => env('FIREBASE_CLIENT_EMAIL'),
+        //     'private_key' => env('FIREBASE_PRIVATE_KEY')
+        // ],
+
+        /**
          * If you want to prevent the auto discovery of credentials, set the
          * following parameter to false. If you disable it, you must
          * provide a credentials file.

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -87,6 +87,8 @@ final class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
             if ($credentialsFile = $config['credentials']['file'] ?? null) {
                 $factory = $factory->withServiceAccount((string) $credentialsFile);
+            } else if ($credentialsArray = $config['credentials']['array'] ?? null) {
+                $factory = $factory->withServiceAccount((array) $credentialsArray);
             }
 
             $enableAutoDiscovery = $config['credentials']['auto_discovery'] ?? true;


### PR DESCRIPTION
First of all, thank you for this amazing library!

I'm running my application in Laravel Vapor and the app doesn't have access to the filesystem. I have to configure the application only using environment variables. This PR address this problem and add an `array` option.