### PR TITLE
Adds HTTP client options 

### DIFF
--- a/config/firebase.php
+++ b/config/firebase.php
@@ -140,4 +140,27 @@ return [
      * Enable debugging of HTTP requests made directly from the SDK.
      */
     'debug' => env('FIREBASE_ENABLE_DEBUG', false),
+
+    /**
+     * ------------------------------------------------------------------------
+     * HTTP Client Options
+     * ------------------------------------------------------------------------
+     *
+     * Behavior of the HTTP Client performing the API requests
+     */
+    'http_client' => [
+
+       /**
+        * Use a proxy that all API requests should be passed through.
+        * (default: none)
+        */
+        'proxy' => env('FIREBASE_HTTP_CLIENT_PROXY', null),
+
+       /**
+        * Set the maximum amount of seconds (float) that can pass before
+        * a request is considered timed out
+        * (default: indefinitely)
+        */
+        'timeout' => env('FIREBASE_HTTP_CLIENT_TIMEOUT', null),
+    ]
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -129,16 +129,17 @@ final class ServiceProvider extends \Illuminate\Support\ServiceProvider
                 );
             }
 
-            $proxy = $config['http_client']['proxy'] ?? null;
-            $timeout = (float) $config['http_client']['timeout'] ?? null;
-            if ($proxy || $timeout) {
-                $options = Firebase\Http\HttpClientOptions::default();
-
-                if ($proxy) $options = $options->withProxy($proxy);
-                if ($timeout) $options = $options->withTimeOut($timeout);
-
-                $factory = $factory->withHttpClientOptions($options);
+            $options = Firebase\Http\HttpClientOptions::default();
+            
+            if ($proxy = $config['http_client']['proxy'] ?? null) {
+                $options = $options->withProxy($proxy);
             }
+            
+            if ($timeout = $config['http_client']['timeout'] ?? null) {
+                $options = $options->withTimeOut((float) $timeout);
+            }
+            
+            $factory = $factory->withHttpClientOptions($options);
 
             return $factory;
         });

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -135,7 +135,7 @@ final class ServiceProvider extends \Illuminate\Support\ServiceProvider
                 $options = Firebase\Http\HttpClientOptions::default();
 
                 if ($proxy) $options = $options->withProxy($proxy);
-                if ($timeout) $options->withTimeOut($timeout);
+                if ($timeout) $options = $options->withTimeOut($timeout);
 
                 $factory = $factory->withHttpClientOptions($options);
             }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -129,6 +129,17 @@ final class ServiceProvider extends \Illuminate\Support\ServiceProvider
                 );
             }
 
+            $proxy = $config['http_client']['proxy'] ?? null;
+            $timeout = (float) $config['http_client']['timeout'] ?? null;
+            if ($proxy || $timeout) {
+                $options = Firebase\Http\HttpClientOptions::default();
+
+                if ($proxy) $options = $options->withProxy($proxy);
+                if ($timeout) $options->withTimeOut($timeout);
+
+                $factory = $factory->withHttpClientOptions($options);
+            }
+
             return $factory;
         });
     }


### PR DESCRIPTION
It makes possible to pass proxy parameter that available at [HTTP Client Options](https://firebase-php.readthedocs.io/en/5.8.1/setup.html#http-client-options)