### PR TITLE
Ensure support for PHP 8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['7.4']
+                php: ['7.4', '8.0']
                 laravel: ['6.0', '7.0', '8.0']
                 include:
                     -   laravel: '8.0'

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^4.0|^5.0|^6.0",
-        "roave/better-reflection": "^3.6|^4.6",
+        "roave/better-reflection": "^3.6|^4.6|5.0.x-dev",
         "friendsofphp/php-cs-fixer": "^2.16"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,27 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-    beStrictAboutOutputDuringTests="true"
-    ignoreDeprecatedCodeUnitsFromCodeCoverage="true"
-    colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" beStrictAboutOutputDuringTests="true" colors="true">
+    <coverage ignoreDeprecatedCodeUnits="true" processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <exclude>
+            <directory>src/Facades</directory>
+        </exclude>
+    </coverage>
     <testsuites>
         <testsuite name="Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-            <exclude>
-                <directory>src/Facades</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-
     <php>
-        <ini name="date.timezone" value="UTC" />
+        <ini name="date.timezone" value="UTC"/>
         <server name="APP_ENV" value="testing"/>
         <server name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
     </php>

--- a/tests/FirebaseProjectManagerTest.php
+++ b/tests/FirebaseProjectManagerTest.php
@@ -337,6 +337,11 @@ final class FirebaseProjectManagerTest extends TestCase
      */
     public function enabling_debug_with_a_boolean_triggers_a_deprecation(): void
     {
+
+        if (version_compare($this->app->version(), '8.65.0', '>=')) {
+            self::markTestSkipped('');
+        }
+
         $this->expectException(\Throwable::class);
         $this->expectExceptionMessageMatches('/deprecated/');
 
@@ -344,6 +349,6 @@ final class FirebaseProjectManagerTest extends TestCase
 
         $this->app->config->set('firebase.projects.'.$projectName.'.debug', true);
 
-        $factory = $this->factoryForProject($projectName);
+        $this->factoryForProject($projectName);
     }
 }


### PR DESCRIPTION
1. Test against php 8.0

2. Skip 'enabling_debug_with_a_boolean_triggers_a_deprecation' test on laravel >= 8.65.0

this is needed due to this PR - https://github.com/laravel/framework/pull/39219
in short - deprecation warnings are not treated as exceptions in laravel anymore.

3. Migrate phpunit.xml.dist schema (./vendor/bin/phpunit --migrate-configuration)