### PR TITLE
Set default timeout for http client

### DIFF
--- a/config/firebase.php
+++ b/config/firebase.php
@@ -181,9 +181,9 @@ return [
                 /*
                  * Set the maximum amount of seconds (float) that can pass before
                  * a request is considered timed out
-                 * (default: indefinitely)
+                 * (default: 30 seconds)
                  */
-                'timeout' => env('FIREBASE_HTTP_CLIENT_TIMEOUT'),
+                'timeout' => env('FIREBASE_HTTP_CLIENT_TIMEOUT', 30),
             ],
         ],
     ],


### PR DESCRIPTION
Hi,

It is recommended to have a sensible default HTTP timeout.

Laravel itself has set a default timeout to their HTTP client.

* https://divinglaravel.com/always-set-a-timeout-for-guzzle-requests-inside-a-queued-job
* https://github.com/laravel/framework/pull/40187
* https://github.com/laravel/framework/pull/40466

It should not be a breaking change for existing users.
