### PR TITLE
add support for Laravel v10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     "require": {
         "php": "~8.1.0 || ~8.2.0",
         "kreait/firebase-php": "^7.0",
-        "illuminate/contracts": "^9.0",
-        "illuminate/support": "^9.0",
+        "illuminate/contracts": "^9.0 || ^10.0",
+        "illuminate/support": "^9.0  || ^10.0",
         "symfony/cache": "^6.1.2"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0",
+        "orchestra/testbench": "^7.0 || ^8.0",
         "symplify/easy-coding-standard": "^11.1"
     },
     "autoload": {


### PR DESCRIPTION
## Description

Laravel 10 will be released on 7th Feb 2023

I could not make the Github actions to pull Laravel 10 :(
May be we should add another matrix for Laravel version.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
