### PR TITLE
fix: pin phpunit to v9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^7.0 || ^8.0",
+        "phpunit/phpunit": "^9.5",    
         "symplify/easy-coding-standard": "^11.1"
     },
     "autoload": {


### PR DESCRIPTION
@jeromegamez 

It looks like composer is picking php-unit v10 due to test-bench v8.x.
We can stick to php unit v9 for now.
This will fix the GitHub actions.