### PR TITLE
Enable injecting middlewares into the Firebase API client

### DIFF
--- a/config/firebase.php
+++ b/config/firebase.php
@@ -179,6 +179,10 @@ return [
                  * https://github.com/kreait/firebase-php/blob/6.x/src/Firebase/Http/HttpClientOptions.php
                  */
                 'timeout' => env('FIREBASE_HTTP_CLIENT_TIMEOUT'),
+
+                'guzzle_middlewares' => [
+
+                ]
             ],
         ],
     ],

--- a/src/FirebaseProjectManager.php
+++ b/src/FirebaseProjectManager.php
@@ -123,6 +123,10 @@ class FirebaseProjectManager
             $options = $options->withTimeOut((float) $timeout);
         }
 
+        if ($middlewares = $config['http_client_options']['guzzle_middlewares'] ?? null) {
+            $options = $options->withGuzzleMiddlewares($middlewares);
+        }
+
         $factory = $factory->withHttpClientOptions($options);
 
         return new FirebaseProject($factory, $config);

--- a/tests/FirebaseProjectManagerTest.php
+++ b/tests/FirebaseProjectManagerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kreait\Laravel\Firebase\Tests;
 
+use GuzzleHttp\RetryMiddleware;
 use Kreait\Firebase;
 use Kreait\Firebase\Exception\InvalidArgumentException;
 use Kreait\Firebase\Factory;
@@ -201,6 +202,7 @@ final class FirebaseProjectManagerTest extends TestCase
         $projectName = $this->app->config->get('firebase.default');
         $this->app->config->set('firebase.projects.' . $projectName . '.http_client_options.proxy', 'proxy.domain.tld');
         $this->app->config->set('firebase.projects.' . $projectName . '.http_client_options.timeout', 1.23);
+        $this->app->config->set('firebase.projects.' . $projectName . '.http_client_options.guzzle_middlewares', [RetryMiddleware::class]);
 
         $factory = $this->factoryForProject($projectName);
 
@@ -209,6 +211,7 @@ final class FirebaseProjectManagerTest extends TestCase
 
         $this->assertSame('proxy.domain.tld', $httpClientOptions->proxy());
         $this->assertSame(1.23, $httpClientOptions->timeout());
+        $this->assertSame([RetryMiddleware::class], $httpClientOptions->guzzleMiddlewares());
     }
 
     /**


### PR DESCRIPTION
# Description

It makes possible adding a Guzzle middleware to the Guzzle HTTP client. This feature was recently introduced in the SDK in [version 7.3.0](https://github.com/kreait/firebase-php/releases/tag/7.3.0)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
