### PR TITLE
Support configuration of credentials with a config array

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ If you prefer to have more control over the configuration items required to conf
 ],
 ```
 
-Feel free to introduce more environment variables as you see fit, for example `env('FIREBASE_CREDENTIALS_APP_PROJECT_ID')`.
-
 ## Usage
 
 Once you have retrieved a component, please refer to the [documentation of the Firebase PHP Admin SDK](https://firebase-php.readthedocs.io)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If you don't want a service account to be auto-discovered, provide it by setting
 FIREBASE_CREDENTIALS=storage/app/firebase-auth.json
 ```
 
-### Credentials with JSON arrays
+### Credentials with Arrays
 
 If you prefer to have more control over the configuration items required to configure the credentials, you can also transpose the Service Account JSON file as an array within your `config/firebase.php` file.
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,15 @@ Please read about the future of the Firebase Admin PHP SDK on the
 
 ---
 
-- [Installation](#installation)
-  - [Laravel](#laravel)
-- [Configuration](#configuration)
-- [Usage](#usage)
-  - [Multiple projects](#multiple-projects)
-- [Supported Versions](#supported-versions)
-- [License](#license)
+-   [Installation](#installation)
+    -   [Laravel](#laravel)
+-   [Configuration](#configuration)
+    -   [Credentials with JSON files](#credentials-with-json-files-auto-discovered)
+    -   [Credentials with arrays](#credentials-with-arrays)
+-   [Usage](#usage)
+    -   [Multiple projects](#multiple-projects)
+-   [Supported Versions](#supported-versions)
+-   [License](#license)
 
 ## Installation
 
@@ -36,12 +38,6 @@ composer require kreait/laravel-firebase
 
 In order to access a Firebase project and its related services using a server SDK, requests must be authenticated.
 For server-to-server communication this is done with a Service Account.
-
-The package uses auto discovery for the default project to find the credentials needed for authenticating requests to
-the Firebase APIs by inspecting certain environment variables and looking into Google's well known path(s).
-
-If you don't want a service account to be auto-discovered, provide it by setting the `GOOGLE_APPLICATION_CREDENTIALS`
-environment variable or by adapting the package configuration.
 
 If you don't already have generated a Service Account, you can do so by following the instructions from the
 official documentation pages at https://firebase.google.com/docs/admin/setup#initialize_the_sdk.
@@ -63,6 +59,39 @@ by copying it to your local `config` directory or by defining the environment va
 # Laravel
 php artisan vendor:publish --provider="Kreait\Laravel\Firebase\ServiceProvider" --tag=config
 ```
+
+### Credentials with JSON files auto-discovered
+
+The package uses auto discovery for the default project to find the credentials needed for authenticating requests to
+the Firebase APIs by inspecting certain environment variables and looking into Google's well known path(s).
+
+If you don't want a service account to be auto-discovered, provide it by setting the `FIREBASE_CREDENTIALS` or `GOOGLE_APPLICATION_CREDENTIALS` environment variable or by adapting the package configuration, like so for example:
+
+```.env
+FIREBASE_CREDENTIALS=storage/app/firebase-auth.json
+```
+
+### Credentials with JSON arrays
+
+If you prefer to have more control over the configuration items required to configure the credentials, you can also transpose the Service Account JSON file as an array within your `config/firebase.php` file.
+
+```php
+'credentials' => [
+    'type' => 'service_account',
+    'project_id' => 'some-project-123',
+    'private_key_id' => '123456789',
+    'private_key' => '-----BEGIN PRIVATE KEY-----\nFOO_BAR_123456789\n-----END PRIVATE KEY-----\n',
+    'client_email' => 'firebase-adminsdk-cwiuo@some-project-123.iam.gserviceaccount.com',
+    'client_id' => '123456789',
+    'auth_uri' => 'https://accounts.google.com/o/oauth2/auth',
+    'token_uri' => 'https://oauth2.googleapis.com/token',
+    'auth_provider_x509_cert_url' => 'https://www.googleapis.com/oauth2/v1/certs',
+    'client_x509_cert_url' => 'https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk-cwiuo%40some-project-123.iam.gserviceaccount.com',
+    'universe_domain' => 'googleapis.com',
+],
+```
+
+Feel free to introduce more environment variables as you see fit, for example `env('FIREBASE_CREDENTIALS_APP_PROJECT_ID')`.
 
 ## Usage
 
@@ -96,7 +125,7 @@ Earlier versions will receive security fixes as long as their **lowest** SDK req
 can find the currently supported versions and support options in the [SDK's README](https://github.com/kreait/firebase-php).
 
 | Version | Initial Release | Supported SDK Versions | Supported Laravel Versions | Status      |
-|---------|-----------------|------------------------|----------------------------|-------------|
+| ------- | --------------- | ---------------------- | -------------------------- | ----------- |
 | `5.x`   | 13 Jan 2023     | `^7.0`                 | `^9.0`                     | Active      |
 | `4.x`   | 09 Jan 2022     | `^6.0`                 | `^8.0`                     | End of life |
 | `3.x`   | 01 Nov 2020     | `^5.24`                | `^6.0, ^7.0, ^8.0`         | End of life |

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ Please read about the future of the Firebase Admin PHP SDK on the
 
 ---
 
--   [Installation](#installation)
-    -   [Laravel](#laravel)
--   [Configuration](#configuration)
-    -   [Credentials with JSON files](#credentials-with-json-files-auto-discovered)
-    -   [Credentials with arrays](#credentials-with-arrays)
--   [Usage](#usage)
-    -   [Multiple projects](#multiple-projects)
--   [Supported Versions](#supported-versions)
--   [License](#license)
+- [Installation](#installation)
+  - [Laravel](#laravel)
+- [Configuration](#configuration)
+  - [Credentials with JSON files](#credentials-with-json-files)
+  - [Credentials with Arrays](#credentials-with-arrays)
+- [Usage](#usage)
+  - [Multiple projects](#multiple-projects)
+- [Supported Versions](#supported-versions)
+- [License](#license)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ by copying it to your local `config` directory or by defining the environment va
 php artisan vendor:publish --provider="Kreait\Laravel\Firebase\ServiceProvider" --tag=config
 ```
 
-### Credentials with JSON files auto-discovered
+### Credentials with JSON files
 
 The package uses auto discovery for the default project to find the credentials needed for authenticating requests to
 the Firebase APIs by inspecting certain environment variables and looking into Google's well known path(s).

--- a/config/firebase.php
+++ b/config/firebase.php
@@ -8,7 +8,6 @@ return [
      * Default Firebase project
      * ------------------------------------------------------------------------
      */
-
     'default' => env('FIREBASE_PROJECT', 'app'),
 
     /*

--- a/config/firebase.php
+++ b/config/firebase.php
@@ -46,9 +46,7 @@ return [
              * first time you try to access a component of the Firebase Admin SDK.
              *
              */
-            'credentials' => [
-                'file' => env('FIREBASE_CREDENTIALS', env('GOOGLE_APPLICATION_CREDENTIALS')),
-            ],
+            'credentials' => env('FIREBASE_CREDENTIALS', env('GOOGLE_APPLICATION_CREDENTIALS')),
 
             /*
              * ------------------------------------------------------------------------

--- a/config/firebase.php
+++ b/config/firebase.php
@@ -16,7 +16,6 @@ return [
      * ------------------------------------------------------------------------
      */
     'projects' => [
-
         'app' => [
             /*
              * ------------------------------------------------------------------------
@@ -47,7 +46,6 @@ return [
              * first time you try to access a component of the Firebase Admin SDK.
              *
              */
-
             'credentials' => env('FIREBASE_CREDENTIALS', env('GOOGLE_APPLICATION_CREDENTIALS')),
 
             /*
@@ -93,7 +91,6 @@ return [
             ],
 
             'dynamic_links' => [
-
                 /*
                  * Dynamic links can be built with any URL prefix registered on
                  *
@@ -105,9 +102,7 @@ return [
                  * The value must be a valid domain, for example,
                  * https://example.page.link
                  */
-
                 'default_domain' => env('FIREBASE_DYNAMIC_LINKS_DEFAULT_DOMAIN'),
-
             ],
 
             /*
@@ -117,7 +112,6 @@ return [
              */
 
             'storage' => [
-
                 /*
                  * Your project's default storage bucket usually uses the project ID
                  * as its name. If you have multiple storage buckets and want to
@@ -126,7 +120,6 @@ return [
                  */
 
                 'default_bucket' => env('FIREBASE_STORAGE_DEFAULT_BUCKET'),
-
             ],
 
             /*
@@ -185,7 +178,7 @@ return [
                  */
                 'timeout' => env('FIREBASE_HTTP_CLIENT_TIMEOUT'),
 
-                // 'guzzle_middlewares' => [],
+                'guzzle_middlewares' => [],
             ],
         ],
     ],

--- a/config/firebase.php
+++ b/config/firebase.php
@@ -80,7 +80,6 @@ return [
                  * Please make sure that you use a full URL like, for example,
                  * https://my-project-id.firebaseio.com
                  */
-
                 'url' => env('FIREBASE_DATABASE_URL'),
 
                 /*

--- a/config/firebase.php
+++ b/config/firebase.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 return [
-
     /*
      * ------------------------------------------------------------------------
      * Default Firebase project

--- a/config/firebase.php
+++ b/config/firebase.php
@@ -3,11 +3,13 @@
 declare(strict_types=1);
 
 return [
+
     /*
      * ------------------------------------------------------------------------
      * Default Firebase project
      * ------------------------------------------------------------------------
      */
+
     'default' => env('FIREBASE_PROJECT', 'app'),
 
     /*
@@ -16,6 +18,7 @@ return [
      * ------------------------------------------------------------------------
      */
     'projects' => [
+
         'app' => [
             /*
              * ------------------------------------------------------------------------
@@ -46,6 +49,7 @@ return [
              * first time you try to access a component of the Firebase Admin SDK.
              *
              */
+
             'credentials' => env('FIREBASE_CREDENTIALS', env('GOOGLE_APPLICATION_CREDENTIALS')),
 
             /*
@@ -76,6 +80,7 @@ return [
                  * Please make sure that you use a full URL like, for example,
                  * https://my-project-id.firebaseio.com
                  */
+
                 'url' => env('FIREBASE_DATABASE_URL'),
 
                 /*
@@ -91,6 +96,7 @@ return [
             ],
 
             'dynamic_links' => [
+
                 /*
                  * Dynamic links can be built with any URL prefix registered on
                  *
@@ -102,7 +108,9 @@ return [
                  * The value must be a valid domain, for example,
                  * https://example.page.link
                  */
+
                 'default_domain' => env('FIREBASE_DYNAMIC_LINKS_DEFAULT_DOMAIN'),
+
             ],
 
             /*
@@ -112,6 +120,7 @@ return [
              */
 
             'storage' => [
+
                 /*
                  * Your project's default storage bucket usually uses the project ID
                  * as its name. If you have multiple storage buckets and want to
@@ -120,6 +129,7 @@ return [
                  */
 
                 'default_bucket' => env('FIREBASE_STORAGE_DEFAULT_BUCKET'),
+
             ],
 
             /*
@@ -178,9 +188,7 @@ return [
                  */
                 'timeout' => env('FIREBASE_HTTP_CLIENT_TIMEOUT'),
 
-                'guzzle_middlewares' => [
-
-                ]
+                // 'guzzle_middlewares' => [],
             ],
         ],
     ],

--- a/src/FirebaseProjectManager.php
+++ b/src/FirebaseProjectManager.php
@@ -68,10 +68,14 @@ class FirebaseProjectManager
             $factory = $factory->withTenantId($tenantId);
         }
 
-        if ($credentials = $config['credentials']['file'] ?? null) {
-            $resolvedCredentials = $this->resolveCredentials((string) $credentials);
+        if ($credentials = $config['credentials'] ?? null) {
+            if (is_string($credentials)) {
+                $factory = $factory->withServiceAccount($this->resolveCredentials($credentials));
+            }
 
-            $factory = $factory->withServiceAccount($resolvedCredentials);
+            if (is_array($credentials)) {
+                $factory = $factory->withServiceAccount($credentials);
+            }
         }
 
         if ($databaseUrl = $config['database']['url'] ?? null) {

--- a/tests/FirebaseProjectManagerTest.php
+++ b/tests/FirebaseProjectManagerTest.php
@@ -87,6 +87,27 @@ final class FirebaseProjectManagerTest extends TestCase
     /**
      * @test
      */
+    public function json_file_credentials_can_be_used_using_the_deprecated_configuration_entry(): void
+    {
+        // Reference credentials
+        $credentialsPath = \realpath(__DIR__ . '/_fixtures/service_account.json');
+        $credentials = \json_decode(\file_get_contents($credentialsPath), true);
+
+        // Set configuration and retrieve project
+        $projectName = 'app';
+        $this->app->config->set('firebase.projects.' . $projectName . '.credentials.file', \realpath(__DIR__ . '/_fixtures/service_account.json'));
+        $factory = $this->factoryForProject($projectName);
+
+        // Retrieve service account
+        $serviceAccount = $this->getAccessibleProperty($factory, 'serviceAccount')->getValue($factory);
+
+        // Validate value
+        $this->assertSame($credentials, $serviceAccount);
+    }
+
+    /**
+     * @test
+     */
     public function credentials_can_be_configured_using_an_array(): void
     {
         // Set configuration and retrieve project

--- a/tests/FirebaseProjectManagerTest.php
+++ b/tests/FirebaseProjectManagerTest.php
@@ -19,7 +19,7 @@ final class FirebaseProjectManagerTest extends TestCase
 {
     protected function defineEnvironment($app): void
     {
-        $app['config']->set('firebase.projects.app.credentials.file', __DIR__ . '/_fixtures/service_account.json');
+        $app['config']->set('firebase.projects.app.credentials', __DIR__ . '/_fixtures/service_account.json');
     }
 
     /**
@@ -66,7 +66,7 @@ final class FirebaseProjectManagerTest extends TestCase
     /**
      * @test
      */
-    public function credentials_can_be_configured(): void
+    public function credentials_can_be_configured_using_a_json_file(): void
     {
         // Reference credentials
         $credentialsPath = \realpath(__DIR__ . '/_fixtures/service_account.json');
@@ -74,7 +74,35 @@ final class FirebaseProjectManagerTest extends TestCase
 
         // Set configuration and retrieve project
         $projectName = 'app';
-        $this->app->config->set('firebase.projects.' . $projectName . '.credentials.file', \realpath(__DIR__ . '/_fixtures/service_account.json'));
+        $this->app->config->set('firebase.projects.' . $projectName . '.credentials', \realpath(__DIR__ . '/_fixtures/service_account.json'));
+        $factory = $this->factoryForProject($projectName);
+
+        // Retrieve service account
+        $serviceAccount = $this->getAccessibleProperty($factory, 'serviceAccount')->getValue($factory);
+
+        // Validate value
+        $this->assertSame($credentials, $serviceAccount);
+    }
+
+    /**
+     * @test
+     */
+    public function credentials_can_be_configured_using_an_array(): void
+    {
+        // Set configuration and retrieve project
+        $projectName = 'app';
+        $this->app->config->set('firebase.projects.' . $projectName . '.credentials', $credentials = [
+            'type' => 'service_account',
+            'project_id' => 'project',
+            'private_key_id' => 'private_key_id',
+            'private_key' => '-----BEGIN PRIVATE KEY-----\nsome gibberish\n-----END PRIVATE KEY-----\n',
+            'client_email' => 'client@email.tld',
+            'client_id' => '1234567890',
+            'auth_uri' => 'https://some.google.tld/o/oauth2/auth',
+            'token_uri' => 'https://some.google.tld/o/oauth2/token',
+            'auth_provider_x509_cert_url' => 'https://some.google.tld/oauth2/v1/certs',
+            'client_x509_cert_url' => 'https://some.google.tld/robot/v1/metadata/x509/user%40project.iam.gserviceaccount.com',
+        ]);
         $factory = $this->factoryForProject($projectName);
 
         // Retrieve service account
@@ -101,8 +129,8 @@ final class FirebaseProjectManagerTest extends TestCase
         $secondProjectName = 'another-app';
 
         // Set service accounts explicitly
-        $this->app->config->set('firebase.projects.' . $projectName . '.credentials.file', \realpath(__DIR__ . '/_fixtures/service_account.json'));
-        $this->app->config->set('firebase.projects.' . $secondProjectName . '.credentials.file', \realpath(__DIR__ . '/_fixtures/another_service_account.json'));
+        $this->app->config->set('firebase.projects.' . $projectName . '.credentials', \realpath(__DIR__ . '/_fixtures/service_account.json'));
+        $this->app->config->set('firebase.projects.' . $secondProjectName . '.credentials', \realpath(__DIR__ . '/_fixtures/another_service_account.json'));
 
         // Retrieve factories and service accounts
         $factory = $this->factoryForProject($projectName);

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -16,7 +16,7 @@ final class ServiceProviderTest extends TestCase
      */
     public function it_provides_components(): void
     {
-        $this->app->config->set('firebase.projects.app.credentials.file', \realpath(__DIR__ . '/_fixtures/service_account.json'));
+        $this->app->config->set('firebase.projects.app.credentials', \realpath(__DIR__ . '/_fixtures/service_account.json'));
 
         $this->assertInstanceOf(Firebase\Contract\AppCheck::class, $this->app->make(Firebase\Contract\AppCheck::class));
         $this->assertInstanceOf(Firebase\Contract\Auth::class, $this->app->make(Firebase\Contract\Auth::class));


### PR DESCRIPTION
# Description

On our applications, in order to have more granularity in the configuration of the credentials, we had to extend the package to be able to optionally receive the configuration of the credentials via an array instead of a JSON file.

This makes it easier to integrate with our CI/CD pipelines and also gives us the ability to cache the config via Laravel.

This is a change we think could be valuable to others too, especially considering that `firebase-php` already supports arrays,

Note: we slightly tweaked the expected configuration array for `credentials` but don't worry this is a non-breaking change.

```diff
- 'credentials' => [
-     'file' => 'some_path.json',
- ],
+ 'credentials' => 'some_path.json',
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation