### PR TITLE
Allow PHP 8.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         php:
-          - "8.1"
           - "8.2"
+          - "8.3"
         laravel:
           - "9"
           - "10"

--- a/README.md
+++ b/README.md
@@ -122,13 +122,14 @@ $anotherAppAuth = Firebase::project('another-app')->auth();
 Earlier versions will receive security fixes as long as their **lowest** SDK requirement receives security fixes. You
 can find the currently supported versions and support options in the [SDK's README](https://github.com/kreait/firebase-php).
 
-| Version | Initial Release | Supported SDK Versions | Supported Laravel Versions | Status      |
-|---------|-----------------|------------------------|----------------------------|-------------|
-| `5.x`   | 13 Jan 2023     | `^7.0`                 | `^9.0`, `^10.0`            | Active      |
-| `4.x`   | 09 Jan 2022     | `^6.0`                 | `^8.0`                     | End of life |
-| `3.x`   | 01 Nov 2020     | `^5.24`                | `^6.0, ^7.0, ^8.0`         | End of life |
-| `2.x`   | 01 Apr 2020     | `^5.0`                 | `^5.8, ^6.0, ^7.0, ^8.0`   | End of life |
-| `1.x`   | 17 Aug 2019     | `^4.40.1`              | `^5.8, ^6.0, ^7.0`         | End of life |
+| Version | Initial Release | Supported SDK Versions | Supported Laravel Versions | Status       |
+|---------|-----------------|------------------------|----------------------------|--------------|
+| `6.x`   | X Dec 2023      | `^7.0`                 | `^10.0`                    | Active       |
+| `5.x`   | 13 Jan 2023     | `^7.0`                 | `6 u^9.0`, `^10.0`         | End of life  |
+| `4.x`   | 09 Jan 2022     | `^6.0`                 | `^8.0`                     | End of life  |
+| `3.x`   | 01 Nov 2020     | `^5.24`                | `^6.0, ^7.0, ^8.0`         | End of life  |
+| `2.x`   | 01 Apr 2020     | `^5.0`                 | `^5.8, ^6.0, ^7.0, ^8.0`   | End of life  |
+| `1.x`   | 17 Aug 2019     | `^4.40.1`              | `^5.8, ^6.0, ^7.0`         | End of life  |
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "~8.1.0 || ~8.2.0",
+        "php": "~8.2.0 || ~8.3.0",
         "kreait/firebase-php": "^7.0",
         "illuminate/contracts": "^9.0 || ^10.0",
         "illuminate/support": "^9.0 || ^10.0",


### PR DESCRIPTION
# Description

Allow PHP 8.3 and drop PHP 8.1

Wait for https://github.com/kreait/firebase-php/pull/847

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
