### PR TITLE
6.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
           - "8.4"
         laravel:
           - "11"
+          - "12"
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,17 +26,11 @@ jobs:
     strategy:
       matrix:
         php:
-          - "8.1"
           - "8.2"
           - "8.3"
           - "8.4"
         laravel:
-          - "9"
-          - "10"
           - "11"
-        exclude:
-          - php: "8.1"
-            laravel: "11"
 
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Added support for Laravel 12
 * Dropped support for Laravel 9 and 10
 * Dropped support for PHP 8.1 (Laravel 11 requires at least PHP 8.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+* Dropped support for Laravel 9 and 10
+* Dropped support for PHP 8.1 (Laravel 11 requires at least PHP 8.2)
+
 ## 5.10.0 - 2024-11-22
 
 * Added support for PHP 8.4

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,15 @@
         }
     ],
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
         "kreait/firebase-php": "^7.13",
-        "illuminate/contracts": "^9.0 || ^10.0 || ^11.0",
-        "illuminate/support": "^9.0 || ^10.0 || ^11.0",
+        "illuminate/contracts": "^11.0",
+        "illuminate/notifications": "^11.0",
+        "illuminate/support": "^11.0",
         "symfony/cache": "^6.1.2 || ^7.0.3"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0 || ^8.0 || ^9.0",
+        "orchestra/testbench": "^9.0",
         "laravel/pint": "^1.14",
         "phpunit/phpunit": "^9.6.17 || ^10.5.13"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
         "kreait/firebase-php": "^7.13",
-        "illuminate/contracts": "^11.0",
-        "illuminate/notifications": "^11.0",
-        "illuminate/support": "^11.0",
+        "illuminate/contracts": "^11.0 || ^12.0",
+        "illuminate/notifications": "^11.0 || ^12.0",
+        "illuminate/support": "^11.0 || ^12.0",
         "symfony/cache": "^6.1.2 || ^7.0.3"
     },
     "require-dev": {
-        "orchestra/testbench": "^9.0",
+        "orchestra/testbench": "^9.0 || ^10.0",
         "laravel/pint": "^1.14",
         "phpunit/phpunit": "^11.4.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "orchestra/testbench": "^9.0",
         "laravel/pint": "^1.14",
-        "phpunit/phpunit": "^9.6.17 || ^10.5.13"
+        "phpunit/phpunit": "^11.4.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-        beStrictAboutOutputDuringTests="true"
-        colors="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+    beStrictAboutOutputDuringTests="true"
+    colors="true"
 >
     <testsuites>
         <testsuite name="Test Suite">
@@ -11,14 +11,14 @@
         </testsuite>
     </testsuites>
 
-    <coverage ignoreDeprecatedCodeUnits="true" processUncoveredFiles="true">
+    <source>
         <include>
-            <directory suffix=".php">src</directory>
+            <directory>src</directory>
         </include>
         <exclude>
             <directory>src/Facades</directory>
         </exclude>
-    </coverage>
+    </source>
 
     <php>
         <ini name="date.timezone" value="UTC"/>

--- a/src/FirebaseProjectManager.php
+++ b/src/FirebaseProjectManager.php
@@ -60,7 +60,7 @@ class FirebaseProjectManager
 
     protected function configure(string $name): FirebaseProject
     {
-        $factory = new Factory();
+        $factory = new Factory;
 
         $config = $this->configuration($name);
 

--- a/tests/FirebaseProjectManagerTest.php
+++ b/tests/FirebaseProjectManagerTest.php
@@ -9,6 +9,7 @@ use Kreait\Firebase;
 use Kreait\Firebase\Exception\InvalidArgumentException;
 use Kreait\Firebase\Factory;
 use Kreait\Laravel\Firebase\FirebaseProjectManager;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Cache\CacheItemPoolInterface;
 use ReflectionObject;
 
@@ -22,9 +23,7 @@ final class FirebaseProjectManagerTest extends TestCase
         $app['config']->set('firebase.projects.app.credentials', __DIR__.'/_fixtures/service_account.json');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function a_project_configuration_has_to_exist(): void
     {
         $manager = $this->app->make(FirebaseProjectManager::class);
@@ -36,9 +35,7 @@ final class FirebaseProjectManagerTest extends TestCase
         $this->getAccessibleMethod($manager, 'configuration')->invoke($manager, $projectName);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function a_default_project_can_be_set(): void
     {
         $manager = $this->app->make(FirebaseProjectManager::class);
@@ -51,9 +48,7 @@ final class FirebaseProjectManagerTest extends TestCase
         $this->assertSame($projectName, $this->app->config->get('firebase.default'), 'default project should be set in config');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function calls_are_passed_to_default_project(): void
     {
         $manager = $this->app->make(FirebaseProjectManager::class);
@@ -63,9 +58,7 @@ final class FirebaseProjectManagerTest extends TestCase
         $this->assertSame($manager->project($projectName)->auth(), $manager->auth());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function credentials_can_be_configured_using_a_json_file(): void
     {
         // Reference credentials
@@ -84,9 +77,7 @@ final class FirebaseProjectManagerTest extends TestCase
         $this->assertSame($credentials, $serviceAccount);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function json_file_credentials_can_be_used_using_the_deprecated_configuration_entry(): void
     {
         // Reference credentials
@@ -105,9 +96,7 @@ final class FirebaseProjectManagerTest extends TestCase
         $this->assertSame($credentials, $serviceAccount);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function credentials_can_be_configured_using_an_array(): void
     {
         // Set configuration and retrieve project
@@ -133,9 +122,7 @@ final class FirebaseProjectManagerTest extends TestCase
         $this->assertSame($credentials, $serviceAccount);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function projects_can_have_different_credentials(): void
     {
         // Reference credentials
@@ -165,9 +152,7 @@ final class FirebaseProjectManagerTest extends TestCase
         $this->assertSame($secondCredentials, $secondServiceAccount);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function the_realtime_database_url_can_be_configured(): void
     {
         $projectName = $this->app->config->get('firebase.default');
@@ -181,9 +166,7 @@ final class FirebaseProjectManagerTest extends TestCase
         $this->assertSame($url, (string) $property->getValue($database));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function the_dynamic_links_default_domain_can_be_configured(): void
     {
         $projectName = $this->app->config->get('firebase.default');
@@ -198,9 +181,7 @@ final class FirebaseProjectManagerTest extends TestCase
         $this->assertSame($domain, $configuredDomain);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function the_storage_default_bucket_can_be_configured(): void
     {
         $projectName = $this->app->config->get('firebase.default');
@@ -213,9 +194,7 @@ final class FirebaseProjectManagerTest extends TestCase
         $this->assertSame($name, $property->getValue($storage));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function logging_can_be_configured(): void
     {
         $projectName = $this->app->config->get('firebase.default');
@@ -228,9 +207,7 @@ final class FirebaseProjectManagerTest extends TestCase
         $this->assertNotNull($property->getValue($factory));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function debug_logging_can_be_configured(): void
     {
         $projectName = $this->app->config->get('firebase.default');
@@ -243,9 +220,7 @@ final class FirebaseProjectManagerTest extends TestCase
         $this->assertNotNull($property->getValue($factory));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function http_client_options_can_be_configured(): void
     {
         $projectName = $this->app->config->get('firebase.default');
@@ -263,9 +238,7 @@ final class FirebaseProjectManagerTest extends TestCase
         $this->assertSame([RetryMiddleware::class], $httpClientOptions->guzzleMiddlewares());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_uses_the_laravel_cache_as_verifier_cache(): void
     {
         $projectName = $this->app->config->get('firebase.default');
@@ -276,9 +249,7 @@ final class FirebaseProjectManagerTest extends TestCase
         $this->assertInstanceOf(CacheItemPoolInterface::class, $property->getValue($factory));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_overrides_the_default_firestore_database(): void
     {
         config(['firebase.projects.app.firestore.database' => 'override-database']);
@@ -290,9 +261,7 @@ final class FirebaseProjectManagerTest extends TestCase
         $this->assertEquals('override-database', $property->getValue($factory)['database']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_uses_the_laravel_cache_as_auth_token_cache(): void
     {
         $projectName = $this->app->config->get('firebase.default');

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -5,15 +5,14 @@ declare(strict_types=1);
 namespace Kreait\Laravel\Firebase\Tests;
 
 use Kreait\Firebase;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
  */
 final class ServiceProviderTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_provides_components(): void
     {
         $this->app->config->set('firebase.projects.app.credentials', \realpath(__DIR__.'/_fixtures/service_account.json'));
@@ -27,9 +26,7 @@ final class ServiceProviderTest extends TestCase
         $this->assertInstanceOf(Firebase\Contract\Storage::class, $this->app->make(Firebase\Contract\Storage::class));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_not_provide_optional_components(): void
     {
         $this->expectException(\Throwable::class);


### PR DESCRIPTION
* Add support for Laravel 12
* Drop support for Laravel 9 and 10
* Drop support for PHP 8.1 (Laravel 11 requires at least PHP 8.2)
* Update PHPUnit

:octocat: 